### PR TITLE
Include kotlin files in the sources jar

### DIFF
--- a/gradle/android-artifacts.gradle
+++ b/gradle/android-artifacts.gradle
@@ -1,4 +1,4 @@
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
+    from android.sourceSets.main.kotlin
 }


### PR DESCRIPTION
Replaces Android's java source files with kotlin ones, otherwise, the generated sources jar is empty.