### PR TITLE
Add HttpClient as MapboxModuleType

### DIFF
--- a/annotations/src/main/java/com/mapbox/annotation/module/MapboxModuleType.kt
+++ b/annotations/src/main/java/com/mapbox/annotation/module/MapboxModuleType.kt
@@ -10,5 +10,10 @@ enum class MapboxModuleType(val interfacePackage: String, val interfaceClassName
   /**
    * Module used to load native libraries.
    */
-  LibraryLoader("com.mapbox.common.module", "LibraryLoader")
+  LibraryLoader("com.mapbox.common.module", "LibraryLoader"),
+
+  /**
+   * Module used to perform http request.
+   */
+  HttpClient("com.mapbox.common", "HttpServiceInterface")
 }


### PR DESCRIPTION
This PR adds a new module type. Not adding the interface definition as this will be coming from the dependency itself. Long term, when we need to expose the same library to other products, we will need to revisit this approach. 