### PR TITLE
Logo contract

### DIFF
--- a/common/src/main/java/com/mapbox/common/plugin/LogoContract.kt
+++ b/common/src/main/java/com/mapbox/common/plugin/LogoContract.kt
@@ -1,0 +1,57 @@
+package com.mapbox.common.plugin
+
+import androidx.annotation.Px
+
+/**
+ * Define the common interfaces for the logo component.
+ */
+interface LogoContract {
+
+  /**
+   * Presenter interface for the logo.
+   */
+  interface LogoPlugin : ViewPlugin {
+    /**
+     * Returns the gravity value of the logo view.
+     */
+    var gravity: Int
+
+    /**
+     * Set the margins of the logo view.
+     *
+     * @param left Margin to the left in pixel
+     * @param top Margin to the top in pixel
+     * @param right Margin to the right in pixel
+     * @param bottom Margin to the bottom in pixel
+     */
+    fun setMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+  }
+
+  /**
+   * Interface for logo view.
+   *
+   * The logo view implementation class should implement both the
+   * LogoView interface and a View class (e.g ImageView).
+   */
+  interface LogoView {
+    /**
+     * Whether the logo view is enabled.
+     */
+    var enabled: Boolean
+
+    /**
+     * Returns the gravity value of the logo view.
+     */
+    var gravity: Int
+
+    /**
+     * Set the margins of the logo view.
+     *
+     * @param left Margin to the left in pixel
+     * @param top Margin to the top in pixel
+     * @param right Margin to the right in pixel
+     * @param bottom Margin to the bottom in pixel
+     */
+    fun setMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+  }
+}


### PR DESCRIPTION
This PR adds a new contract to the common plugin package:
 - LogoContract

Contents are based on CompassContract but I opted to not include Logo in the method naming. Thoughts? Should we include it always or align CompassContract to the PR contents? 