### PR TITLE
Improve readability of nested module creation exceptions

### DIFF
--- a/common/src/main/java/com/mapbox/common/module/provider/MapboxInvalidModuleException.kt
+++ b/common/src/main/java/com/mapbox/common/module/provider/MapboxInvalidModuleException.kt
@@ -8,7 +8,7 @@ import com.mapbox.annotation.module.MapboxModuleType
 /**
  * An exception thrown when there's a missing or wrongly implemented Mapbox module.
  */
-class MapboxInvalidModuleException(type: MapboxModuleType) : RuntimeException(
+data class MapboxInvalidModuleException(private val type: MapboxModuleType) : RuntimeException(
   """
     ${type.name} has been excluded from build but a correct alternative was not provided.
     Make sure that:

--- a/examples/src/main/java/com/mapbox/common/examples/MyLogger.kt
+++ b/examples/src/main/java/com/mapbox/common/examples/MyLogger.kt
@@ -1,0 +1,31 @@
+package com.mapbox.common.examples
+
+import com.mapbox.annotation.module.MapboxModule
+import com.mapbox.annotation.module.MapboxModuleType
+import com.mapbox.navigation.base.logger.Logger
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.base.logger.model.Tag
+import com.mapbox.navigation.base.trip.TripNotification
+
+@MapboxModule(MapboxModuleType.CommonLogger)
+class MyLogger(notification: TripNotification) : Logger {
+  override fun d(tag: Tag?, msg: Message, tr: Throwable?) {
+    TODO("not implemented")
+  }
+
+  override fun e(tag: Tag?, msg: Message, tr: Throwable?) {
+    TODO("not implemented")
+  }
+
+  override fun i(tag: Tag?, msg: Message, tr: Throwable?) {
+    TODO("not implemented")
+  }
+
+  override fun v(tag: Tag?, msg: Message, tr: Throwable?) {
+    TODO("not implemented")
+  }
+
+  override fun w(tag: Tag?, msg: Message, tr: Throwable?) {
+    TODO("not implemented")
+  }
+}

--- a/examples/src/main/java/com/mapbox/common/examples/MyOnboardRouter.kt
+++ b/examples/src/main/java/com/mapbox/common/examples/MyOnboardRouter.kt
@@ -1,13 +1,13 @@
 package com.mapbox.common.examples
 
-import android.content.Context
 import com.mapbox.annotation.module.MapboxModule
 import com.mapbox.annotation.module.MapboxModuleType
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.logger.Logger
 import com.mapbox.navigation.base.route.Router
 
 @MapboxModule(MapboxModuleType.NavigationOnboardRouter, enableConfiguration = true)
-class MyOnboardRouter(context: Context) : Router {
+class MyOnboardRouter(logger: Logger) : Router {
   override fun cancel() {
     // not implemented
   }

--- a/examples/src/test/java/com/mapbox/common/examples/ModuleProviderTest.kt
+++ b/examples/src/test/java/com/mapbox/common/examples/ModuleProviderTest.kt
@@ -6,15 +6,20 @@ import com.mapbox.common.module.LibraryLoader
 import com.mapbox.common.module.provider.MapboxInvalidModuleException
 import com.mapbox.common.module.provider.MapboxModuleProvider
 import com.mapbox.module.Mapbox_OnboardRouterModuleConfiguration
+import com.mapbox.navigation.base.logger.Logger
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.trip.TripNotification
 import io.mockk.mockk
+import org.hamcrest.core.IsEqual
 import org.junit.Assert.assertNotNull
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 class ModuleProviderTest {
 
-  private val context: Context = mockk()
+  @get:Rule
+  var exceptionRule = ExpectedException.none()!!
 
   @Test
   fun no_dependencies() {
@@ -37,28 +42,36 @@ class ModuleProviderTest {
   @Test
   fun generate_configuration() {
     Mapbox_OnboardRouterModuleConfiguration.moduleProvider = object : Mapbox_OnboardRouterModuleConfiguration.ModuleProvider {
-      override fun createOnboardRouter(): Router = MyOnboardRouter(context)
+      override fun createOnboardRouter(): Router = MyOnboardRouter(mockk())
     }
     val onboardRouter: Router = MapboxModuleProvider.createModule(MapboxModuleType.NavigationOnboardRouter, ::paramsProvider)
     assertNotNull(onboardRouter)
   }
 
-  @Test(expected = MapboxInvalidModuleException::class)
+  @Test
   fun missing_module_impl() {
-    val tripNotification: TripNotification = MapboxModuleProvider.createModule(MapboxModuleType.NavigationTripNotification, ::paramsProvider)
-    assertNotNull(tripNotification)
+    exceptionRule.expect(IsEqual(MapboxInvalidModuleException(MapboxModuleType.NavigationTripNotification)))
+    MapboxModuleProvider.createModule<TripNotification>(MapboxModuleType.NavigationTripNotification, ::paramsProvider)
+  }
+
+  @Test
+  fun missing_nested_module_impl() {
+    exceptionRule.expect(IsEqual(MapboxInvalidModuleException(MapboxModuleType.NavigationTripNotification)))
+    MapboxModuleProvider.createModule<Logger>(MapboxModuleType.CommonLogger, ::paramsProvider)
   }
 
   private fun paramsProvider(type: MapboxModuleType): Array<Pair<Class<*>?, Any?>> {
     return when (type) {
       MapboxModuleType.CommonLibraryLoader -> arrayOf()
       MapboxModuleType.CommonHttpClient -> TODO("not implemented")
-      MapboxModuleType.CommonLogger -> TODO("not implemented")
+      MapboxModuleType.CommonLogger -> arrayOf(
+        Router::class.java to MapboxModuleProvider.createModule(MapboxModuleType.NavigationTripNotification, ::paramsProvider)
+      )
       MapboxModuleType.NavigationRouter -> arrayOf(
         Router::class.java to MapboxModuleProvider.createModule(MapboxModuleType.NavigationOffboardRouter, ::paramsProvider)
       )
       MapboxModuleType.NavigationOffboardRouter -> arrayOf(
-        Context::class.java to context
+        Context::class.java to mockk<Context>()
       )
       MapboxModuleType.NavigationOnboardRouter -> arrayOf()
       MapboxModuleType.NavigationTripNotification -> TODO("not implemented")


### PR DESCRIPTION
This PR makes sure to catch and rethrow an exception that points to the correct, nested module definition. Before, if one module was depending on another, and the nested module failed to load, the exception would bubble up recursively and would point to the top-level module instead of the one that actually failed.