### PR TITLE
Use strong class reference for no-config glue class

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -82,7 +82,7 @@ class HttpClientImpl(private val okHttpClient: OkHttpClient) : HttpClient, HttpC
   }
 }
 ```
-This class can live anywhere in the project or dependency tree.
+This class can live anywhere in the project or dependency tree, but it has to be publicly available.
 
 ### Module annotations
 To limit erroneous runtime configurations and simplify the configuration, it’s required to annotate a module implementation with the appropriate annotation from the `com.mapbox.base:annotations` artifact found in [this package](https://github.com/mapbox/mapbox-base-android/tree/master/annotations/src/main/java/com/mapbox/annotation):
@@ -123,10 +123,7 @@ object Mapbox_HttpClientModuleConfiguration {
   val enableConfiguration: Boolean = false
 
   @JvmStatic
-  val implPackage: String = "com.mapbox.maps.module.http"
-
-  @JvmStatic
-  val implClassName: String = "HttpClientImpl"
+  val implClass: Class<HttpClientImpl> = HttpClientImpl::class.java
 }
 ```
 

--- a/annotations-processor/src/main/java/com/mapbox/annotation/processor/ModuleProviderGenerator.kt
+++ b/annotations-processor/src/main/java/com/mapbox/annotation/processor/ModuleProviderGenerator.kt
@@ -5,6 +5,7 @@ import com.google.auto.service.AutoService
 import com.mapbox.annotation.*
 import com.mapbox.annotation.module.MapboxModule
 import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.jvm.jvmStatic
 import java.nio.file.Paths
 import javax.annotation.processing.AbstractProcessor
@@ -136,17 +137,12 @@ internal class ModuleProviderGenerator : AbstractProcessor() {
     } else {
       // if configuration is disabled, generate only impl package and class paths for manual instantiation
       typeBuilder.addProperty(
-        PropertySpec.builder(
-          MODULE_CONFIGURATION_DISABLED_PACKAGE, String::class)
-          .initializer("\"${module.implPackage}\"")
+        PropertySpec.builder(MODULE_CONFIGURATION_DISABLED_CLASS,
+          ClassName.bestGuess("java.lang.Class").parameterizedBy(ClassName.bestGuess("${module.implPackage}.${module.implClassName}")))
+          .initializer("${module.implClassName}::class.java")
           .jvmStatic()
-          .build())
-      typeBuilder.addProperty(
-        PropertySpec.builder(
-          MODULE_CONFIGURATION_DISABLED_CLASS, String::class)
-          .initializer("\"${module.implClassName}\"")
-          .jvmStatic()
-          .build())
+          .build()
+      )
     }
 
     fileBuilder.addType(typeBuilder.build())

--- a/annotations/src/main/java/com/mapbox/annotation/MapboxAnnotationConstants.kt
+++ b/annotations/src/main/java/com/mapbox/annotation/MapboxAnnotationConstants.kt
@@ -20,14 +20,9 @@ const val MODULE_CONFIGURATION_CLASS_NAME_FORMAT = "Mapbox_%sModuleConfiguration
 const val MODULE_CONFIGURATION_ENABLE_CONFIGURATION = "enableConfiguration"
 
 /**
- * When configuration is disabled, module implementation package string variable name.
+ * When configuration is disabled, module implementation class reference variable name.
  */
-const val MODULE_CONFIGURATION_DISABLED_PACKAGE = "implPackage"
-
-/**
- * When configuration is disabled, module implementation class name string variable name.
- */
-const val MODULE_CONFIGURATION_DISABLED_CLASS = "implClassName"
+const val MODULE_CONFIGURATION_DISABLED_CLASS = "implClass"
 
 /**
  * When configuration is enabled, configuration's module provider class name.

--- a/annotations/src/main/java/com/mapbox/annotation/module/MapboxModule.kt
+++ b/annotations/src/main/java/com/mapbox/annotation/module/MapboxModule.kt
@@ -5,6 +5,8 @@ import com.mapbox.annotation.MODULE_CONFIGURATION_CLASS_NAME_FORMAT
 /**
  * Annotation that marks an implementation class of the Mapbox module.
  *
+ * The implementation class has to be public.
+ *
  * For additional documentation and examples, see
  * [MODULARIZATION.md](https://github.com/mapbox/mapbox-base-android/blob/master/MODULARIZATION.md).
  *

--- a/common/src/main/java/com/mapbox/common/module/provider/MapboxModuleProvider.kt
+++ b/common/src/main/java/com/mapbox/common/module/provider/MapboxModuleProvider.kt
@@ -56,11 +56,8 @@ object MapboxModuleProvider {
         }
       } else {
         // configuration was disabled, we should get the implementation's class and instantiate it
-        val implPackage =
-          configurationClass.getMethod(MODULE_CONFIGURATION_DISABLED_PACKAGE.asGetterFun()).invoke(null) as String
-        val implClassName =
-          configurationClass.getMethod(MODULE_CONFIGURATION_DISABLED_CLASS.asGetterFun()).invoke(null) as String
-        val implClass = Class.forName("$implPackage.$implClassName")
+        val implClass =
+          configurationClass.getMethod(MODULE_CONFIGURATION_DISABLED_CLASS.asGetterFun()).invoke(null) as Class<T>
 
         var foundInstance: Any? = null
         for (creator in instanceCreators) {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-base-android/issues/31.

Instead of storing `String` references to the class, we can actually import the implementation class which not only saves us one reflection class lookup, but also prevents minification of the implementation class thanks to a binary reference.