### PR TITLE
Keep current names of Bintray project names

### DIFF
--- a/annotations-processor/gradle.properties
+++ b/annotations-processor/gradle.properties
@@ -3,3 +3,4 @@ POM_ARTIFACT_ID=annotations-processor
 POM_ARTIFACT_GROUP_ID=com.mapbox.base
 POM_ARTIFACT_TITLE=Mapbox Annotations Processor
 POM_DESCRIPTION=Artifact that provides Mapbox module and plugin generators
+BINTRAY_PROJECT_NAME=annotations-processor

--- a/annotations/gradle.properties
+++ b/annotations/gradle.properties
@@ -3,3 +3,4 @@ POM_ARTIFACT_ID=annotations
 POM_ARTIFACT_GROUP_ID=com.mapbox.base
 POM_ARTIFACT_TITLE=Mapbox Annotations
 POM_DESCRIPTION=Artifact that provides Mapbox module and plugin annotations
+BINTRAY_PROJECT_NAME=annotations

--- a/common/gradle.properties
+++ b/common/gradle.properties
@@ -3,3 +3,4 @@ POM_ARTIFACT_ID=common
 POM_ARTIFACT_GROUP_ID=com.mapbox.base
 POM_ARTIFACT_TITLE=Mapbox Common
 POM_DESCRIPTION=Artifact that provides Mapbox module and plugin contracts
+BINTRAY_PROJECT_NAME=common

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -14,6 +14,7 @@ ext {
 
     mapboxBintrayUserOrg = 'mapbox'
     mapboxBintrayRepoName = 'mapbox'
+    mapboxBintrayProjectName = project.property('BINTRAY_PROJECT_NAME')
     mapboxBintrayUser = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
     mapboxBintrayApiKey = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
     mapboxGpgPassphrase = project.hasProperty('GPG_PASSPHRASE') ? project.property('GPG_PASSPHRASE') : System.getenv('GPG_PASSPHRASE')

--- a/gradle/bintray-publish.gradle
+++ b/gradle/bintray-publish.gradle
@@ -55,7 +55,7 @@ bintray {
     publications('MapboxBasePublication')
     pkg {
         repo = project.ext.mapboxBintrayRepoName
-        name = group + ':' + project.ext.mapboxArtifactId
+        name = project.ext.mapboxBintrayProjectName
         userOrg = project.ext.mapboxBintrayUserOrg
         licenses = [project.ext.mapboxArtifactLicenseName]
         vcsUrl = project.ext.mapboxArtifactVcsUrl

--- a/liblogger/gradle.properties
+++ b/liblogger/gradle.properties
@@ -3,3 +3,4 @@ POM_ARTIFACT_ID=logger
 POM_ARTIFACT_GROUP_ID=com.mapbox.common
 POM_ARTIFACT_TITLE=Mapbox Logger
 POM_DESCRIPTION=Artifact that provides Mapbox Logger module implementation
+BINTRAY_PROJECT_NAME=com.mapbox.common:logger


### PR DESCRIPTION
Since all packages besides `logger` are already being published, this PR fixes the build script to keep their names.