### PR TITLE
Add docs about preventing minification

### DIFF
--- a/MODULARIZATION.md
+++ b/MODULARIZATION.md
@@ -112,9 +112,9 @@ To make both Mapbox default module implementations and custom ones testable, and
 When `enableConfiguration = false`, the processor will not generate the configuration option in the resulting glue class. This results in the module provider trying to:
 
 1. instantiate the module by the public, no-arg constructor
-2. obtain the Kotlin `object` reference of the module implementation
-3. call a static, Java `getInstance` method
-4. call the constructor that accepts a list of default parameters, for Mapbox default modules internal usage only.
+2. obtain the Kotlin `object` reference of the module implementation **(make sure to prevent minification/obfuscation of the `object.INSTANCE` field)**
+3. call a static, Java `getInstance` method **(make sure to prevent minification/obfuscation of the `getInstance` method)**
+4. call the constructor that accepts a list of default parameters, for Mapbox default modules internal usage only **(Mapbox SDK needs to make sure to prevent minification/obfuscation of the desired constructor)**.
 
 ```
 @Keep

--- a/annotations/src/main/java/com/mapbox/annotation/module/MapboxModule.kt
+++ b/annotations/src/main/java/com/mapbox/annotation/module/MapboxModule.kt
@@ -24,8 +24,8 @@ import com.mapbox.annotation.MODULE_CONFIGURATION_CLASS_NAME_FORMAT
  * @param enableConfiguration Defaults to false. If set to `false`, the generator will not expose the module provider.
  * The SDK will then try to:
  * 1. Call an empty constructor of the annotated implementation class.
- * 2. Get a Kotlin `object` instance.
- * 3. Get class' instance using a static `getInstance` method.
+ * 2. Get a Kotlin `object` instance. **(make sure to prevent minification/obfuscation of the `object.INSTANCE` field)**
+ * 3. Get class' instance using a static `getInstance` method. **(make sure to prevent minification/obfuscation of the `getInstance` method)**
  * 4. Create the instance by injecting predefined Mapbox parameters. This is for internal and Mapbox default modules use only.
  *
  * If set to `true`, the SDK will generate a static provider, with class name equal to: [MODULE_CONFIGURATION_CLASS_NAME_FORMAT].


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-base-android/issues/31.

The issue is removed fields or constructors used for instantiation. I can't see a way for us to automatically keep those but the good news is, that this in nearly all cases impacting only the Mapbox SDKs, not end users.