### PR TITLE
Improve module exception errors by printing creation failure cause

### DIFF
--- a/common/src/main/java/com/mapbox/common/module/provider/MapboxModuleProvider.kt
+++ b/common/src/main/java/com/mapbox/common/module/provider/MapboxModuleProvider.kt
@@ -59,6 +59,7 @@ object MapboxModuleProvider {
         val implClass =
           configurationClass.getMethod(MODULE_CONFIGURATION_DISABLED_CLASS.asGetterFun()).invoke(null) as Class<T>
 
+        val creationExceptions = mutableListOf<String>()
         var foundInstance: Any? = null
         for (creator in instanceCreators) {
           try {
@@ -66,12 +67,24 @@ object MapboxModuleProvider {
           } catch (ex: Exception) {
             if (ex is MapboxInvalidModuleException) {
               throw ex
+            } else {
+              creationExceptions.add(ex.toString())
             }
           }
           if (foundInstance != null) {
             break
           }
         }
+
+        if (foundInstance == null) {
+          val stream = System.err
+          synchronized(stream) {
+            creationExceptions.forEach {
+              stream.println(it)
+            }
+          }
+        }
+
         instance = foundInstance ?: throw MapboxInvalidModuleException(type)
       }
 


### PR DESCRIPTION
This makes sure to also print the module creation failures if all methods fail.