### PR TITLE
Add map attribution delegate

### DIFF
--- a/common/src/main/java/com/mapbox/common/plugin/MapDelegateProvider.kt
+++ b/common/src/main/java/com/mapbox/common/plugin/MapDelegateProvider.kt
@@ -1,5 +1,7 @@
 package com.mapbox.common.plugin
 
+import com.mapbox.common.plugin.attribution.MapAttributionDelegate
+
 /**
  * Definition of map delegate transporter. Provides hooks to all map delegate instances.
  */
@@ -9,4 +11,9 @@ interface MapDelegateProvider {
    * Delegate used to interact with map's camera.
    */
   val mapCameraDelegate: MapCameraDelegate
+
+  /**
+   * Delegate used to retrieve the sources attribution.
+   */
+  val mapAttributionDelegate: MapAttributionDelegate
 }

--- a/common/src/main/java/com/mapbox/common/plugin/attribution/Attribution.kt
+++ b/common/src/main/java/com/mapbox/common/plugin/attribution/Attribution.kt
@@ -1,0 +1,32 @@
+package com.mapbox.common.plugin.attribution
+
+/**
+ * Attribution model class.
+ *
+ * @property title the attribution title
+ * @property titleAbbreviated the shortened attribution title
+ * @property url the attribution URL
+ */
+data class Attribution(val title: String, val url: String) {
+
+  val titleAbbreviated: String
+    get() = if (title == OSM) OSM_ABBR else title
+
+  /**
+   * Attribution constant values
+   *
+   * @property OSM OpenStreetMap
+   * @property OSM_ABBR OpenStreetMap abbreviated as OSM
+   * @property TELEMETRY_SETTINGS Telemetry settings
+   * @property ABOUT_MAPS_URL Mapbox about maps URL
+   * @property ABOUT_TELEMETRY_URL Mapbox about telemetry URL
+   *
+   */
+  companion object {
+    const val OSM = "OpenStreetMap"
+    const val OSM_ABBR = "OSM"
+    const val TELEMETRY_SETTINGS = "Telemetry Settings"
+    const val ABOUT_MAPS_URL = "https://www.mapbox.com/about/maps/"
+    const val ABOUT_TELEMETRY_URL = "https://www.mapbox.com/telemetry/"
+  }
+}

--- a/common/src/main/java/com/mapbox/common/plugin/attribution/AttributionContract.kt
+++ b/common/src/main/java/com/mapbox/common/plugin/attribution/AttributionContract.kt
@@ -1,0 +1,74 @@
+package com.mapbox.common.plugin.attribution
+
+import androidx.annotation.Px
+import com.mapbox.common.plugin.ViewPlugin
+
+/**
+* Define the common interfaces for the attribution component.
+*/
+interface AttributionContract {
+
+  /**
+   * Listener to get OnClick event on the view.
+   */
+  interface OnAttributionClickListener {
+
+    /**
+     * Invoked when the attribution is clicked.
+     */
+    fun onAttributionClick()
+  }
+
+  /**
+   * Presenter interface for the attribution.
+   */
+  interface AttributionPlugin : ViewPlugin {
+    /**
+     * Returns the gravity value of the attribution view.
+     */
+    var attributionGravity: Int
+
+    /**
+     * Set the margins of the attribution view.
+     *
+     * @param left Margin to the left in pixel
+     * @param top Margin to the top in pixel
+     * @param right Margin to the right in pixel
+     * @param bottom Margin to the bottom in pixel
+     */
+    fun setAttributionMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+
+    /**
+     * Invoked when the attribution view is clicked.
+     */
+    fun onAttributionClicked()
+  }
+
+  /**
+   * Interface for attribution view.
+   *
+   * The attribution view implementation class should implement both the
+   * AttributionView interface and a View class (e.g ImageView).
+   */
+  interface AttributionView {
+    /**
+     * Whether the attribution view is enabled.
+     */
+    var attributionEnabled: Boolean
+
+    /**
+     * Returns the gravity value of the attribution view.
+     */
+    var attributionGravity: Int
+
+    /**
+     * Set the margins of the attribution view.
+     *
+     * @param left Margin to the left in pixel
+     * @param top Margin to the top in pixel
+     * @param right Margin to the right in pixel
+     * @param bottom Margin to the bottom in pixel
+     */
+    fun setAttributionMargins(@Px left: Int, @Px top: Int, @Px right: Int, @Px bottom: Int)
+  }
+}

--- a/common/src/main/java/com/mapbox/common/plugin/attribution/MapAttributionDelegate.kt
+++ b/common/src/main/java/com/mapbox/common/plugin/attribution/MapAttributionDelegate.kt
@@ -1,0 +1,13 @@
+package com.mapbox.common.plugin.attribution
+
+/**
+ * Definition of a attribution delegate.
+ * Any invocation will query the map style sources for attribution.
+ */
+interface MapAttributionDelegate {
+
+  /**
+   * Delegate for querying the map for sources attribution.
+   */
+  fun querySourcesAttribution(): List<Attribution>
+}


### PR DESCRIPTION
This PR adds an attribution delegate that will delegate the querying of the map to get source attribution data and show it to end-user. 