### PR TITLE
[common] change kotlin module name to common-android

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,6 +13,10 @@ android {
     targetSdkVersion(AndroidVersions.targetSdkVersion)
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
+  kotlinOptions{
+    freeCompilerArgs = listOf("-module-name", "common-android")
+  }
 }
 
 dependencies {


### PR DESCRIPTION
closes #53 

Validated with `./gradlew common:assembleRelease' and checking the aar content:

![Screenshot from 2020-09-18 13-09-44](https://user-images.githubusercontent.com/2151639/93591372-8807e300-f9b0-11ea-958f-84ed4ff9ef5f.png)
