### PR TITLE
Enable incremental processing for ModuleProviderGenerator.

### DIFF
--- a/annotations-processor/build.gradle.kts
+++ b/annotations-processor/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
   implementation(Dependencies.kotlinPoet)
   implementation(Dependencies.serviceProvider)
   kapt(Dependencies.serviceProvider)
+  compileOnly(Dependencies.incapRuntime)
+  kapt(Dependencies.incapProcessor)
 }
 
 project.apply {

--- a/annotations-processor/src/main/java/com/mapbox/annotation/processor/ModuleProviderGenerator.kt
+++ b/annotations-processor/src/main/java/com/mapbox/annotation/processor/ModuleProviderGenerator.kt
@@ -14,6 +14,8 @@ import javax.annotation.processing.RoundEnvironment
 import javax.annotation.processing.SupportedOptions
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType
 
 /**
  * For additional documentation and examples, see
@@ -21,6 +23,7 @@ import javax.lang.model.element.TypeElement
  */
 @SupportedOptions(ModuleProviderGenerator.KAPT_KOTLIN_GENERATED_OPTION_NAME)
 @AutoService(Processor::class)
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 internal class ModuleProviderGenerator : AbstractProcessor() {
 
   override fun getSupportedSourceVersion(): SourceVersion {

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -20,9 +20,12 @@ object Dependencies {
   const val mockk = "io.mockk:mockk:${Versions.mockk}"
   const val junit = "androidx.test.ext:junit:${Versions.junit}"
   const val navigationBase = "com.mapbox.navigation:base:${Versions.navigationBase}"
+  const val incapRuntime = "net.ltgt.gradle.incap:incap:${Versions.incap}"
+  const val incapProcessor = "net.ltgt.gradle.incap:incap-processor:${Versions.incap}"
 }
 
 private object Versions {
+  const val incap = "0.3"
   const val tools = "4.1.3"
   const val kotlin = "1.4.10"
   const val androidX = "1.1.0"

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -1,1 +1,4 @@
 android.useAndroidX = true
+kapt.incremental.apt=true
+kapt.use.worker.api=true
+kapt.verbose=true


### PR DESCRIPTION
For reference: https://docs.gradle.org/current/userguide/java_plugin.html#sec:incremental_annotation_processing

> Starting with Gradle 4.7, the incremental compiler also supports incremental annotation processing. All annotation processors need to opt in to this feature, otherwise they will trigger a full recompilation.

[The whole Gradle module will be non-incremental](https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/) if there is just one non-incremental annotation processor. We need to make sure that all annotation processors in the module support incremental kapt.

This PR adds incremental annotation processing support to ModuleProviderGenerator. More specifically, it makes ModuleProviderGenerator an isolating annotation processor. This PR also introduces https://github.com/tbroyer/gradle-incap-helper as compile dependency to generate the META-INF descriptor.


cc @LukasPaczos @tobrun 