### PR TITLE
Remove MapboxModuleType.NavigationRouter

### DIFF
--- a/annotations/src/main/java/com/mapbox/annotation/module/MapboxModuleType.kt
+++ b/annotations/src/main/java/com/mapbox/annotation/module/MapboxModuleType.kt
@@ -50,12 +50,6 @@ enum class MapboxModuleType(
   /* ----- NAVIGATION MODULES ----- */
 
   /**
-   * Main router used by the Navigation SDK.
-   */
-  @Deprecated("Core Navigation Framework doesn't use a custom router implementation so it will not overwrite the built-in router in Core Navigation Framework anymore")
-  NavigationRouter("Router", "com.mapbox.navigation.base.route", "Router"),
-
-  /**
    * Foreground service notification displayed when navigation's trip session is started.
    */
   NavigationTripNotification("TripNotification", "com.mapbox.navigation.base.trip.notification", "TripNotification")

--- a/examples/src/test/java/com/mapbox/common/examples/ModuleProviderTest.kt
+++ b/examples/src/test/java/com/mapbox/common/examples/ModuleProviderTest.kt
@@ -61,9 +61,6 @@ class ModuleProviderTest {
       MapboxModuleType.CommonLogger -> arrayOf(
         ModuleProviderArgument(TripNotification::class.java, MapboxModuleProvider.createModule(MapboxModuleType.NavigationTripNotification, ::paramsProvider))
       )
-      MapboxModuleType.NavigationRouter -> arrayOf(
-        ModuleProviderArgument(LibraryLoader::class.java, MapboxModuleProvider.createModule(MapboxModuleType.CommonLibraryLoader, ::paramsProvider))
-      )
       MapboxModuleType.NavigationTripNotification -> arrayOf()
       MapboxModuleType.MapTelemetry -> arrayOf()
     }


### PR DESCRIPTION
Decided to remove it since it's not used anymore and ability to overwrite NavigationRouter has been removed in the Navigation SDK v3

https://github.com/mapbox/mapbox-base-android/pull/76 should be merged first