### PR TITLE
Bump navigation core version to 3.3.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 dependencies {
   implementation("com.android.tools.build:gradle:4.1.3")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")
   implementation(gradleApi())
   implementation(localGroovy())
 }

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -29,7 +29,7 @@ private object Versions {
   const val tools = "4.1.3"
   const val kotlin = "1.4.10"
   const val androidX = "1.1.0"
-  const val license = "0.8.5"
+  const val license = "0.8.91"
   const val kotlinPoet = "1.6.0"
   const val serviceProvider = "1.0-rc7"
   const val dokka = "0.9.18"

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -27,7 +27,7 @@ object Dependencies {
 private object Versions {
   const val incap = "0.3"
   const val tools = "4.1.3"
-  const val kotlin = "1.4.10"
+  const val kotlin = "1.5.0"
   const val androidX = "1.1.0"
   const val license = "0.8.91"
   const val kotlinPoet = "1.6.0"

--- a/buildSrc/src/main/kotlin/Project.kt
+++ b/buildSrc/src/main/kotlin/Project.kt
@@ -19,7 +19,7 @@ object Dependencies {
   const val serviceProvider = "com.google.auto.service:auto-service:${Versions.serviceProvider}"
   const val mockk = "io.mockk:mockk:${Versions.mockk}"
   const val junit = "androidx.test.ext:junit:${Versions.junit}"
-  const val navigationBase = "com.mapbox.navigation:base:${Versions.navigationBase}"
+  const val navigationBase = "com.mapbox.navigationcore:base:${Versions.navigationBase}"
   const val incapRuntime = "net.ltgt.gradle.incap:incap:${Versions.incap}"
   const val incapProcessor = "net.ltgt.gradle.incap:incap-processor:${Versions.incap}"
 }
@@ -36,7 +36,7 @@ private object Versions {
   const val sdkRegistry = "0.7.0"
   const val mockk = "1.10.0"
   const val junit = "1.1.2"
-  const val navigationBase = "1.0.0-rc.6"
+  const val navigationBase = "3.3.0"
 }
 
 object ArtifactSettings {


### PR DESCRIPTION
Also updated the licence gradle plugin since 0.8.5 version is no longer available in JCenter (licence plugin 0.8.91 requires kotlin 1.5.0)

see details https://blog.gradle.org/portal-jcenter-impact#impact-plugins